### PR TITLE
feat(rules): add skills and feats endpoints (RPGT-20, RPGT-21)

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ async function main() {
 
     log(filename,": Defining Routes");
 
-    log(filename,": Defining SRD");
+    log(filename,": Defining Rules");
     const rulesRouter = require('./routes/rules');
     log(filename,": Defining System");
     const systemRouter = require('./routes/system');

--- a/app.js
+++ b/app.js
@@ -1,5 +1,8 @@
 // Main app file for test api
 
+// get environement
+require('dotenv').config();
+
 // create express and initialize modules
 const express = require('express'); 
 const app = express(); //create app
@@ -44,11 +47,14 @@ async function main() {
     const rulesRouter = require('./routes/rules');
     log(filename,": Defining System");
     const systemRouter = require('./routes/system');
+    log(filename,": Defining Admin");
+    const adminRouter = require('./routes/admin');
 
     //hook up routers
     log(filename,": Hooking up routes");
     app.use('/rules', rulesRouter); //rules functions
     app.use('/api', systemRouter); //system functions
+    app.use('/admin', adminRouter); //admin functions
 
     // grab port as argument from commandline, else default to port in config file
     // note to self, add checking to ensure argv[2] is numeric in valid port range

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,0 +1,50 @@
+const { log } = require('../utils/logger');
+const path = require('path');
+const filename = path.basename(__filename);
+const adminModel = require('../models/adminModel');
+const { successResponse, errorResponse } = require('../utils/dbUtils');
+
+async function getUsers(req, res) {
+    const { page, perPage, query } = req.query;
+
+    try {
+        const data = await adminModel.getUsers(page, perPage, query);
+        res.json(successResponse(data));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse("INTERNAL_SERVER_ERROR", "Failed to fetch users"));
+    }
+}
+
+async function assignRole(req, res) {
+    const { userId } = req.params;
+    const { role } = req.body;
+
+    if (!role) return res.status(400).json(errorResponse("MISSING_PARAMETERS", "role is required"));
+
+    try {
+        const data = await adminModel.assignUserRole(userId, role);
+        res.json(successResponse(data));
+    } catch (err) {
+        log(filename, err);
+        res.status(err.status ?? 500).json(errorResponse(err.code ?? "INTERNAL_SERVER_ERROR", err.message));
+    }
+}
+
+async function removeRole(req, res) {
+    const { userId, role } = req.params;
+
+    try {
+        const data = await adminModel.removeUserRole(userId, role);
+        res.json(successResponse(data));
+    } catch (err) {
+        log(filename, err);
+        res.status(err.status ?? 500).json(errorResponse(err.code ?? "INTERNAL_SERVER_ERROR", err.message));
+    }
+}
+
+module.exports = { 
+    getUsers,
+    assignRole,
+    removeRole
+}

--- a/controllers/featController.js
+++ b/controllers/featController.js
@@ -32,9 +32,10 @@ async function getById(req, res) {
 
 async function create(req, res) {
     const pool = req.app.locals.db;
-    const { name, source_book_id } = req.body;
+    const { name, source_book_id, benefit } = req.body;
     if (!name) return res.status(400).json(errorResponse("MISSING_NAME", "Name is required"));
     if (!source_book_id) return res.status(400).json(errorResponse("MISSING_SOURCE_BOOK", "Source Book ID is required"));
+    if (!benefit) return res.status(400).json(errorResponse("MISSING_BENEFIT", "Benefit is required"));
     try {
         const result = await featModel.createFeat(pool, req.body);
         const newFeat = await featModel.getFeatById(pool, result.insertId);

--- a/controllers/featController.js
+++ b/controllers/featController.js
@@ -1,0 +1,46 @@
+const { log } = require('../utils/logger');
+const path = require('path'); //add path module
+const filename = path.basename(__filename); // for logging purposes
+const featModel = require('../models/featModel');
+const { successResponse, errorResponse } = require('../utils/dbUtils');
+
+async function getAll(req, res) {
+    const pool = req.app.locals.db;
+    try {
+        const data = await featModel.getFeats(pool);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "No feats found"));
+        res.json(successResponse(data, { count: data.length }));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function getById(req, res) {
+    const pool = req.app.locals.db;
+    const { id } = req.params;
+    if (!id) return res.status(400).json(errorResponse("MISSING_ID", "ID parameter is required"));
+    try {
+        const data = await featModel.getFeatById(pool, id);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "Feat not found"));
+        res.json(successResponse(data[0]));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function create() {}
+async function getByType() {}
+async function updateById() {}
+async function deleteById() {}
+
+
+module.exports = { 
+    getAll,
+    getById,
+    create,
+    getByType,
+    updateById,
+    deleteById
+}

--- a/controllers/featController.js
+++ b/controllers/featController.js
@@ -30,10 +30,47 @@ async function getById(req, res) {
     }
 }
 
-async function create() {}
-async function getByType() {}
-async function updateById() {}
-async function deleteById() {}
+async function create(req, res) {
+    const pool = req.app.locals.db;
+    try {
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function getByType(req, res) {
+    const pool = req.app.locals.db;
+    const { type } = req.params;
+    try {
+        const data = await featModel.getFeatsByType(pool, type);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", `No feats found for type: ${type}`));
+        res.json(successResponse(data, { count: data.length }));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function updateById(req, res) {
+    const pool = req.app.locals.db;
+    try {
+
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function deleteById(req, res) {
+    const pool = req.app.locals.db;
+    try {
+
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
 
 
 module.exports = { 

--- a/controllers/featController.js
+++ b/controllers/featController.js
@@ -32,7 +32,13 @@ async function getById(req, res) {
 
 async function create(req, res) {
     const pool = req.app.locals.db;
+    const { name, source_book_id } = req.body;
+    if (!name) return res.status(400).json(errorResponse("MISSING_NAME", "Name is required"));
+    if (!source_book_id) return res.status(400).json(errorResponse("MISSING_SOURCE_BOOK", "Source Book ID is required"));
     try {
+        const result = await featModel.createFeat(pool, req.body);
+        const newFeat = await featModel.getFeatById(pool, result.insertId);
+        res.status(201).json(successResponse(newFeat[0]));
     } catch (err) {
         log(filename, err);
         res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
@@ -54,8 +60,12 @@ async function getByType(req, res) {
 
 async function updateById(req, res) {
     const pool = req.app.locals.db;
+    const { id } = req.params;
     try {
-
+        const result = await featModel.updateFeat(pool, id, req.body);
+        if (!result.affectedRows) return res.status(404).json(errorResponse("NOT_FOUND", "Feat not found."));
+        const updated = await featModel.getFeatById(pool, id);
+        res.json(successResponse(updated[0]));
     } catch (err) {
         log(filename, err);
         res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
@@ -64,8 +74,11 @@ async function updateById(req, res) {
 
 async function deleteById(req, res) {
     const pool = req.app.locals.db;
+    const { id } = req.params;
     try {
-
+        const result = await featModel.deleteFeat(pool, id);
+        if (!result.affectedRows) return res.status(404).json(errorResponse("NOT_FOUND", "Feat not found."));
+        res.json(successResponse(null, { message: "Feat deleted successfully" }));
     } catch (err) {
         log(filename, err);
         res.status(500).json(errorResponse('DB_ERROR', 'Database error'));

--- a/controllers/featController.js
+++ b/controllers/featController.js
@@ -86,6 +86,59 @@ async function deleteById(req, res) {
     }
 }
 
+async function addPrereq(req, res) {
+    const pool = req.app.locals.db;
+    const { id } = req.params;
+    const { prereq_type } = req.body;
+    if (!prereq_type) return res.status(400).json(errorResponse("MISSING_PREREQ_TYPE", "Prerequisite type is required"));
+    try {
+        const result = await featModel.createPrereq(pool, id, req.body);
+        const row = await featModel.getPrereqById(pool, result.insertId);
+        res.status(201).json(successResponse(row[0]));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+/* add/update prerequisite request body template:
+{
+  "prereq_type": "feat",
+  "prereq_value": "Familiar",
+  "prereq_min": null,
+  "prereq_key": null,
+  "prereq_feat_id": null,
+  "prereq_skill_id": null
+}
+*/
+
+
+async function updatePrereqById(req, res) {
+    const pool = req.app.locals.db;
+    const { id, prereqId } = req.params;
+    try {
+        const result = await featModel.updatePrereqById(pool, id, prereqId, req.body);
+        if (!result.affectedRows) return res.status(404).json(errorResponse("PREREQ_NOT_FOUND", "Prerequisite not found."));
+        const row = await featModel.getPrereqById(pool, prereqId);
+        res.json(successResponse(row[0]));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+    
+async function deletePrereqById(req, res) {
+    const pool = req.app.locals.db;
+    const { id, prereqId } = req.params;
+    try {
+        const result = await featModel.deletePrereqById(pool, id, prereqId);
+        if (!result.affectedRows) return res.status(404).json(errorResponse("PREREQ_NOT_FOUND", "Prerequisite not found."));
+        res.json(successResponse(null, { message: "Prerequisite deleted successfully" }));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
 
 module.exports = { 
     getAll,
@@ -93,5 +146,8 @@ module.exports = {
     create,
     getByType,
     updateById,
-    deleteById
+    deleteById,
+    addPrereq,
+    updatePrereqById,
+    deletePrereqById
 }

--- a/controllers/referenceController.js
+++ b/controllers/referenceController.js
@@ -1,0 +1,39 @@
+// Catch all for data that doesn't have enough endpoints to warrant its own model/controller.
+
+const { log } = require('../utils/logger');
+const path = require('path'); //add path module
+const filename = path.basename(__filename); // for logging purposes
+const referenceModel = require('../models/referenceModel');
+const { successResponse, errorResponse } = require('../utils/dbUtils');
+
+async function getAllSourceBooks(req, res) {
+    const pool = req.app.locals.db;
+    try {
+        const data = await referenceModel.getSourceBooks(pool);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "No source books found"));
+        res.json(successResponse(data, { count: data.length }));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function getSourceBookById(req, res) {
+    const pool = req.app.locals.db;
+    const { id } = req.params;
+    if (!id) return res.status(400).json(errorResponse("MISSING_ID", "ID parameter is required"));
+    try {
+        const data = await referenceModel.getSourceBookById(pool, id);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "Source book not found"));
+        res.json(successResponse(data[0]));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+
+module.exports = {
+    getAllSourceBooks,
+    getSourceBookById
+}

--- a/controllers/skillController.js
+++ b/controllers/skillController.js
@@ -1,0 +1,36 @@
+const { log } = require('../utils/logger');
+const path = require('path'); //add path module
+const filename = path.basename(__filename); // for logging purposes
+const skillModel = require('../models/skillModel');
+const { successResponse, errorResponse } = require('../utils/dbUtils');
+
+async function getAll(req, res) {
+    const pool = req.app.locals.db;
+    try {
+        const data = await skillModel.getSkills(pool);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "No skills found"));
+        res.json(successResponse(data, { count: data.length }));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+async function getById(req, res) {
+    const pool = req.app.locals.db;
+    const { id } = req.params;
+    if (!id) return res.status(400).json(errorResponse("MISSING_ID", "ID parameter is required"));
+    try {
+        const data = await skillModel.getSkillById(pool, id);
+        if (!data.length) return res.status(404).json(errorResponse("NOT_FOUND", "Skill not found"));
+        res.json(successResponse(data[0]));
+    } catch (err) {
+        log(filename, err);
+        res.status(500).json(errorResponse('DB_ERROR', 'Database error'));
+    }
+}
+
+module.exports = {
+    getAll,
+    getById
+}

--- a/models/adminModel.js
+++ b/models/adminModel.js
@@ -1,0 +1,81 @@
+const { getRoleMap, listUsers, getUserRoles, assignRole, removeRole, getRoleUsers } = require('../services/auth0Management');
+const { ROLES } = require('@axiom/aegis');
+
+async function getUsers(page, perPage, query) {
+
+    const result = await listUsers(page, perPage, query);
+
+    const users = await Promise.all(
+    result.users.map(async (user) => {
+        const roles = await getUserRoles(user.user_id);
+        return {
+            user_id: user.user_id,
+            email:   user.email,
+            name:    user.name,
+            picture: user.picture,
+            roles:   roles.map(r => r.name),
+        };
+    }));
+
+    return {
+        users,
+        page:    result.start / result.limit + 1,
+        perPage: result.limit,
+        total:   result.total,
+    };
+}
+
+async function assignUserRole(targetUserId, roleName) {
+    const assignableRoles = Object.keys(ROLES);
+    if (!assignableRoles.includes(roleName)) {
+        const err = new Error(`Invalid role: ${roleName}`);
+        err.status = 400;
+        err.code = 'INVALID_ROLE';
+        throw err;
+    }
+ 
+    const targetRoles = await getUserRoles(targetUserId);
+    const targetRoleNames = targetRoles.map(r => r.name);
+
+    if (targetRoleNames.includes(roleName)) return { user_id: targetUserId, roles: targetRoleNames };
+
+    await assignRole(targetUserId, roleName);
+    const updated = await getUserRoles(targetUserId);
+    return { user_id: targetUserId, roles: updated.map(r => r.name) };
+}
+
+async function removeUserRole(targetUserId, roleName) {
+    const assignableRoles = Object.keys(ROLES).filter(r => r !== 'User');
+    if (!assignableRoles.includes(roleName)) {
+        const err = new Error(`Invalid role: ${roleName}`);
+        err.status = 400;
+        err.code = 'INVALID_ROLE';
+        throw err;
+    }
+ 
+    const targetRoles = await getUserRoles(targetUserId);
+    const targetRoleNames = targetRoles.map(r => r.name);
+
+    if (!targetRoleNames.includes(roleName)) return { user_id: targetUserId, roles: targetRoleNames };
+
+    if (roleName === 'Owner') {
+        const roleMap = await getRoleMap();
+        const owners = await getRoleUsers(roleMap['Owner']);
+        if (owners.length <= 1) {
+            const err = new Error('Cannot remove the last Owner');
+            err.status = 409;
+            err.code = 'LAST_OWNER';
+            throw err;
+        }
+    }
+
+    await removeRole(targetUserId, roleName);
+    const updated = await getUserRoles(targetUserId);
+    return { user_id: targetUserId, roles: updated.map(r => r.name) };
+}
+
+module.exports = { 
+    getUsers,
+    assignUserRole,
+    removeUserRole
+}

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -110,6 +110,7 @@ module.exports = {
     createFeat,
     updateFeat,
     deleteFeat,
+    getPrereqById,
     createPrereq,
     updatePrereqById,
     deletePrereqById

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -1,5 +1,6 @@
 const { executeQuery } = require('../utils/dbUtils');
 const PATCHABLE = ['name', 'feat_type', 'prerequisites', 'benefit', 'normal', 'special', 'description'];
+const PREREQ_PATCHABLE = ['prereq_type', 'prereq_value', 'prereq_min', 'prereq_key', 'prereq_feat_id', 'prereq_skill_id'];
 
 
 async function getFeats(pool) {
@@ -52,6 +53,12 @@ async function createFeat(pool, data) {
     return executeQuery(pool,sql,params);
 }
 
+async function getPrereqById(pool, prereqId) {
+    const sql = 'SELECT * FROM feat_prerequisites WHERE id = ?';
+    const params = [prereqId];
+    return executeQuery(pool,sql,params);
+}
+
 async function updateFeat(pool, id, data) {
     const fields = Object.keys(data).filter(key => PATCHABLE.includes(key));
     if (!fields.length) return { affectedRows: 0 };
@@ -66,7 +73,35 @@ async function deleteFeat(pool, id) {
     return executeQuery(pool,sql,params);
 }
 
+async function createPrereq(pool, featId, data) {
+    const sql = `INSERT INTO feat_prerequisites (feat_id, prereq_type, prereq_value, prereq_min, prereq_key, prereq_feat_id, prereq_skill_id)
+                 VALUES (?, ?, ?, ?, ?, ?, ?)`;
+    const params = [
+        featId,
+        data.prereq_type,
+        data.prereq_value ?? null,
+        data.prereq_min ?? null,
+        data.prereq_key ?? null,
+        data.prereq_feat_id ?? null,
+        data.prereq_skill_id ?? null
+    ];
+    return executeQuery(pool,sql,params);
+}
 
+async function updatePrereqById(pool, featId, prereqId, data) {
+    const fields = Object.keys(data).filter(key => PREREQ_PATCHABLE.includes(key));
+    if (!fields.length) return { affectedRows: 0 };
+    const sql = `UPDATE feat_prerequisites SET ${fields.map(f => `${f} = ?`).join(', ')} WHERE feat_id = ? AND id = ?`;
+    const params = [...fields.map(f => data[f]), featId, prereqId];
+    return executeQuery(pool,sql,params);
+
+}
+
+async function deletePrereqById(pool, featId, prereqId) {
+    const sql = 'DELETE FROM feat_prerequisites WHERE feat_id = ? AND id = ?';
+    const params = [featId, prereqId];
+    return executeQuery(pool,sql,params);
+}
 
 module.exports = { 
     getFeats,
@@ -74,5 +109,8 @@ module.exports = {
     getFeatsByType,
     createFeat,
     updateFeat,
-    deleteFeat
+    deleteFeat,
+    createPrereq,
+    updatePrereqById,
+    deletePrereqById
 }

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -17,7 +17,7 @@ async function getFeatById(pool, id) {
 
     // build sql statement with variable placeholders
     const featSql = 'SELECT * FROM feats f where f.id = ?';
-    const prereqSql = `SELECT prereq_type, prereq_value, prereq_min, prereq_key, prereq_feat_id, prereq_skill_id FROM feat_prerequisites WHERE feat_id = ? ORDER BY id ASC`;
+    const prereqSql = `SELECT id, prereq_type, prereq_value, prereq_min, prereq_key, prereq_feat_id, prereq_skill_id FROM feat_prerequisites WHERE feat_id = ? ORDER BY id ASC`;
 
     const [feats, prereqs] = await Promise.all([
         executeQuery(pool, featSql, [id]),

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -15,10 +15,19 @@ async function getFeats(pool) {
 async function getFeatById(pool, id) {
 
     // build sql statement with variable placeholders
-    const sql = 'SELECT * FROM feats f where f.id = ?';
-    const params = [id];
+    const featSql = 'SELECT * FROM feats f where f.id = ?';
+    const prereqSql = `SELECT prereq_type, prereq_value, prereq_min, prereq_key, prereq_feat_id, prereq_skill_id FROM feat_prerequisites WHERE feat_id = ? ORDER BY id ASC`;
 
-    return executeQuery(pool,sql,params);
+    const [feats, prereqs] = await Promise.all([
+        executeQuery(pool, featSql, [id]),
+        executeQuery(pool, prereqSql, [id])
+    ]);
+
+    if (!feats.length) return [];
+    return [{
+        ...feats[0],
+        prerequisites: prereqs
+    }];
 }   
 
 async function getFeatsByType(pool, type) {
@@ -35,7 +44,7 @@ async function createFeat(pool, data) {
         data.name,
         data.feat_type    ?? null,
         data.prerequisites ?? null,
-        data.benefit      ?? null,
+        data.benefit,
         data.normal       ?? null,
         data.special      ?? null,
         data.description  ?? null,

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -28,17 +28,32 @@ async function getFeatsByType(pool, type) {
 }
 
 async function createFeat(pool, data) {
-
+    const sql = `INSERT INTO feats (source_book_id, name, feat_type, prerequisites, benefit, normal, special, description)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`;
+    const params = [
+        data.source_book_id,
+        data.name,
+        data.feat_type    ?? null,
+        data.prerequisites ?? null,
+        data.benefit      ?? null,
+        data.normal       ?? null,
+        data.special      ?? null,
+        data.description  ?? null,
+    ];
     return executeQuery(pool,sql,params);
 }
 
 async function updateFeat(pool, id, data) {
-
+    const fields = Object.keys(data).filter(key => PATCHABLE.includes(key));
+    if (!fields.length) return { affectedRows: 0 };
+    const sql = `UPDATE feats SET ${fields.map(f => `${f} = ?`).join(', ')} WHERE id = ?`;
+    const params = [...fields.map(f => data[f]), id];
     return executeQuery(pool,sql,params);
 }
 
 async function deleteFeat(pool, id) {
-
+    const sql = 'DELETE FROM feats WHERE id = ?';
+    const params = [id];
     return executeQuery(pool,sql,params);
 }
 

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -1,4 +1,6 @@
 const { executeQuery } = require('../utils/dbUtils');
+const PATCHABLE = ['name', 'feat_type', 'prerequisites', 'benefit', 'normal', 'special', 'description'];
+
 
 async function getFeats(pool) {
 
@@ -19,8 +21,34 @@ async function getFeatById(pool, id) {
     return executeQuery(pool,sql,params);
 }   
 
+async function getFeatsByType(pool, type) {
+    const sql = 'SELECT * FROM feats f where f.feat_type = ?';
+    const params = [type];
+    return executeQuery(pool,sql,params);
+}
+
+async function createFeat(pool, data) {
+
+    return executeQuery(pool,sql,params);
+}
+
+async function updateFeat(pool, id, data) {
+
+    return executeQuery(pool,sql,params);
+}
+
+async function deleteFeat(pool, id) {
+
+    return executeQuery(pool,sql,params);
+}
+
+
 
 module.exports = { 
     getFeats,
-    getFeatById 
+    getFeatById,
+    getFeatsByType,
+    createFeat,
+    updateFeat,
+    deleteFeat
 }

--- a/models/featModel.js
+++ b/models/featModel.js
@@ -1,0 +1,26 @@
+const { executeQuery } = require('../utils/dbUtils');
+
+async function getFeats(pool) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM feats f';
+    const params = [];
+
+    return executeQuery(pool,sql,params);
+
+}
+
+async function getFeatById(pool, id) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM feats f where f.id = ?';
+    const params = [id];
+
+    return executeQuery(pool,sql,params);
+}   
+
+
+module.exports = { 
+    getFeats,
+    getFeatById 
+}

--- a/models/referenceModel.js
+++ b/models/referenceModel.js
@@ -1,0 +1,27 @@
+// Catch all for data that doesn't have enough endpoints to warrant its own model/controller.
+
+const { executeQuery } = require('../utils/dbUtils');
+
+async function getSourceBooks(pool) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM source_books sb';
+    const params = [];
+
+    return executeQuery(pool,sql,params);
+}
+
+async function getSourceBookById(pool, id) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM source_books sb where sb.id = ?';
+    const params = [id];
+
+    return executeQuery(pool,sql,params);
+}   
+
+
+module.exports = {
+    getSourceBooks,
+    getSourceBookById
+}

--- a/models/skillModel.js
+++ b/models/skillModel.js
@@ -7,7 +7,6 @@ async function getSkills(pool) {
     const params = [];
 
     return executeQuery(pool,sql,params);
-
 }
 
 async function getSkillById(pool, id) {

--- a/models/skillModel.js
+++ b/models/skillModel.js
@@ -1,0 +1,26 @@
+const { executeQuery } = require('../utils/dbUtils');
+
+async function getSkills(pool) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM skills s';
+    const params = [];
+
+    return executeQuery(pool,sql,params);
+
+}
+
+async function getSkillById(pool, id) {
+
+    // build sql statement with variable placeholders
+    const sql = 'SELECT * FROM skills s where s.id = ?';
+    const params = [id];
+
+    return executeQuery(pool,sql,params);
+}   
+
+
+module.exports = {
+    getSkills,
+    getSkillById
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,20 +9,37 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "body-parser": "^1.20.0",
-        "connect-roles": "^3.1.2",
+        "@axiom/aegis": "file:../aegis",
         "cors": "^2.8.5",
+        "dotenv": "^17.4.2",
         "express": "^4.18.1",
-        "fs": "^0.0.1-security",
-        "mysql": "^2.18.1",
-        "nodemon": "^2.0.19",
-        "path": "^0.12.7"
+        "mysql": "^2.18.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "eslint": "^10.2.1",
-        "globals": "^17.5.0"
+        "globals": "^17.5.0",
+        "nodemon": "^3.1.14"
       }
+    },
+    "../aegis": {
+      "name": "@axiom/aegis",
+      "version": "0.2.0",
+      "license": "ISC",
+      "dependencies": {
+        "express-jwt": "^8.4.1",
+        "jwks-rsa": "^3.1.0"
+      },
+      "devDependencies": {
+        "jest": "^29.7.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0"
+      }
+    },
+    "node_modules/@axiom/aegis": {
+      "resolved": "../aegis",
+      "link": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -77,27 +94,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@eslint/config-array/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -113,21 +109,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@eslint/config-array/node_modules/ms": {
@@ -281,11 +262,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -339,6 +315,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -352,15 +330,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "node_modules/asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha512-Ej9qjcXY+8Tuy1cNqiwNMwFRXOy9UwgTeMA8LxreodygIPV48lx8PU1ecFxb5ZeU1DpMKxiq6vGLTxcitWZPbA=="
-    },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.0.0",
@@ -371,51 +349,39 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
       },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -441,21 +407,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/character-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
-      "integrity": "sha512-DcT7xnScdoZy9nFFIjJ5uAUNCsiXzMgmNSAWK3XDXpHtlrlgmPhzYWAw/CxWCbuisIDh7xsfyJTm0lIWHknpog=="
-    },
     "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -468,23 +425,11 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/connect-roles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/connect-roles/-/connect-roles-3.1.2.tgz",
-      "integrity": "sha512-Fw4q/nN2C+vQ20cTWy+TAJ+qqMpGB0xU6vNC8zewnCLnnLYtvoIvyJrHjEFzOO+dShTFT8GxUupN+n3NzpbIcw==",
-      "dependencies": {
-        "ert": "^1.0.1",
-        "path-to-regexp": "^1.0.1",
-        "promise": "^6.0.1"
       }
     },
     "node_modules/content-disposition": {
@@ -581,6 +526,17 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -592,14 +548,6 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/ert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ert/-/ert-1.0.1.tgz",
-      "integrity": "sha512-boNmnWh7BiX1IV6bvetuEnr2HVHJlYmTlKT1S+TG3tb2DFGkWcytgCuHIWW5g/MEODHYMoLPN/42iWHEcliryQ==",
-      "dependencies": {
-        "character-parser": "~1.0.0"
       }
     },
     "node_modules/escape-html": {
@@ -704,27 +652,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/eslint/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -752,21 +679,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint/node_modules/ms": {
@@ -956,9 +868,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1034,16 +948,13 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
-    },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1074,6 +985,8 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1108,6 +1021,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1161,7 +1076,9 @@
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -1189,6 +1106,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1200,6 +1119,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1208,6 +1128,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1219,14 +1140,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1341,14 +1259,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -1390,17 +1313,19 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
@@ -1409,7 +1334,7 @@
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -1417,36 +1342,36 @@
       }
     },
     "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/nodemon/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1533,15 +1458,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1560,18 +1476,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1588,26 +1498,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/promise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-      "integrity": "sha512-O+uwGKreKNKkshzZv2P7N64lk6EP17iXBn0PbUnNQhk+Q0AHLstiTrjkx3v5YBd3cxUe7Sq6KyRhl/A0xUjk7Q==",
-      "dependencies": {
-        "asap": "~1.0.0"
-      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1624,7 +1518,9 @@
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -1657,20 +1553,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -1699,6 +1581,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1731,11 +1615,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -1820,22 +1709,16 @@
       }
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "semver": "~7.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=10"
       }
     },
     "node_modules/sqlstring": {
@@ -1871,6 +1754,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1882,6 +1767,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1898,12 +1785,11 @@
       }
     },
     "node_modules/touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
@@ -1935,7 +1821,9 @@
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1954,23 +1842,10 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2026,6 +1901,14 @@
     }
   },
   "dependencies": {
+    "@axiom/aegis": {
+      "version": "file:../aegis",
+      "requires": {
+        "express-jwt": "^8.4.1",
+        "jest": "^29.7.0",
+        "jwks-rsa": "^3.1.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -2060,21 +1943,6 @@
         "minimatch": "^10.2.4"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2082,15 +1950,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.3"
-          }
-        },
-        "minimatch": {
-          "version": "10.2.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-          "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^5.0.5"
           }
         },
         "ms": {
@@ -2198,11 +2057,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2241,6 +2095,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2251,15 +2106,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
-    "asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha512-Ej9qjcXY+8Tuy1cNqiwNMwFRXOy9UwgTeMA8LxreodygIPV48lx8PU1ecFxb5ZeU1DpMKxiq6vGLTxcitWZPbA=="
-    },
     "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true
     },
     "bignumber.js": {
       "version": "9.0.0",
@@ -2267,44 +2118,27 @@
       "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
     "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
-      "requires": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      }
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "bytes": {
@@ -2321,15 +2155,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "character-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.0.2.tgz",
-      "integrity": "sha512-DcT7xnScdoZy9nFFIjJ5uAUNCsiXzMgmNSAWK3XDXpHtlrlgmPhzYWAw/CxWCbuisIDh7xsfyJTm0lIWHknpog=="
-    },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2339,21 +2169,6 @@
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "connect-roles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/connect-roles/-/connect-roles-3.1.2.tgz",
-      "integrity": "sha512-Fw4q/nN2C+vQ20cTWy+TAJ+qqMpGB0xU6vNC8zewnCLnnLYtvoIvyJrHjEFzOO+dShTFT8GxUupN+n3NzpbIcw==",
-      "requires": {
-        "ert": "^1.0.1",
-        "path-to-regexp": "^1.0.1",
-        "promise": "^6.0.1"
       }
     },
     "content-disposition": {
@@ -2428,6 +2243,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
+    "dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2437,14 +2257,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
-    },
-    "ert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ert/-/ert-1.0.1.tgz",
-      "integrity": "sha512-boNmnWh7BiX1IV6bvetuEnr2HVHJlYmTlKT1S+TG3tb2DFGkWcytgCuHIWW5g/MEODHYMoLPN/42iWHEcliryQ==",
-      "requires": {
-        "character-parser": "~1.0.0"
-      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2495,21 +2307,6 @@
         "optionator": "^0.9.3"
       },
       "dependencies": {
-        "balanced-match": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-          "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^4.0.2"
-          }
-        },
         "debug": {
           "version": "4.4.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2526,15 +2323,6 @@
           "dev": true,
           "requires": {
             "is-glob": "^4.0.3"
-          }
-        },
-        "minimatch": {
-          "version": "10.2.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-          "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^5.0.5"
           }
         },
         "ms": {
@@ -2712,9 +2500,10 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -2769,15 +2558,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
-    },
     "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -2799,6 +2584,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -2820,7 +2606,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -2856,7 +2643,8 @@
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2878,6 +2666,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -2885,12 +2674,14 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -2898,12 +2689,8 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2991,11 +2778,12 @@
       }
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       }
     },
     "ms": {
@@ -3033,49 +2821,45 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
       "requires": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "^2.1.3"
           }
         },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
         }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3132,15 +2916,6 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3153,18 +2928,11 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -3172,23 +2940,10 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-      "integrity": "sha512-O+uwGKreKNKkshzZv2P7N64lk6EP17iXBn0PbUnNQhk+Q0AHLstiTrjkx3v5YBd3cxUe7Sq6KyRhl/A0xUjk7Q==",
-      "requires": {
-        "asap": "~1.0.0"
-      }
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -3202,7 +2957,8 @@
     "pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
     },
     "punycode": {
       "version": "2.3.1",
@@ -3222,17 +2978,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "requires": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      }
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -3264,6 +3009,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -3279,9 +3025,10 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true
     },
     "send": {
       "version": "0.18.0",
@@ -3352,18 +3099,12 @@
       }
     },
     "simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
       "requires": {
-        "semver": "~7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
-        }
+        "semver": "^7.5.3"
       }
     },
     "sqlstring": {
@@ -3395,6 +3136,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -3403,6 +3145,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -3413,12 +3156,10 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "requires": {
-        "nopt": "~1.0.10"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -3441,7 +3182,8 @@
     "undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -3455,21 +3197,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
-        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,18 +15,16 @@
   "author": "Justin McClellan",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.20.0",
-    "connect-roles": "^3.1.2",
+    "@axiom/aegis": "file:../aegis",
     "cors": "^2.8.5",
+    "dotenv": "^17.4.2",
     "express": "^4.18.1",
-    "fs": "^0.0.1-security",
-    "mysql": "^2.18.1",
-    "nodemon": "^2.0.19",
-    "path": "^0.12.7"
+    "mysql": "^2.18.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "eslint": "^10.2.1",
-    "globals": "^17.5.0"
+    "globals": "^17.5.0",
+    "nodemon": "^3.1.14"
   }
 }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,0 +1,25 @@
+// admin endpoints
+
+const express = require('express');
+const admin = express.Router();
+const adminController = require('../controllers/adminController.js');
+
+const { createRequireAuth, requireRole, requireMinRole } = require('@axiom/aegis');
+const requireAuth = createRequireAuth({
+    domain: process.env.AUTH0_DOMAIN,
+    audience: process.env.AUTH0_AUDIENCE,
+});
+
+admin.use(requireAuth);
+admin.use(requireMinRole('Admin')); // all routes in this router require admin role 
+
+admin.route('/users')
+    .get(adminController.getUsers)
+
+admin.route('/users/:userId/roles')
+    .post(requireRole('Owner'), adminController.assignRole)
+
+admin.route('/users/:userId/roles/:role')
+    .delete(requireRole('Owner'), adminController.removeRole);
+
+module.exports = admin;

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -51,9 +51,9 @@ rules.route('/skills/:id')
 
 // Book routes
 rules.route('/sourcebooks')
-    .get(referenceController.getAll);
+    .get(referenceController.getAllSourceBooks);
 
 rules.route('/sourcebooks/:id')
-    .get(referenceController.getById);
+    .get(referenceController.getSourceBookById);
 
 module.exports = rules

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -1,48 +1,55 @@
-// Main routes file for SRD specific endpoints
+// Main routes file for rules specific endpoints
 
 const express = require('express');
-const srd = express.Router();
+const rules = express.Router();
 const spellController = require('../controllers/spellController.js');
 const classController = require('../controllers/classController.js');
 const featController = require('../controllers/featController.js');
+const skillController = require('../controllers/skillController.js');
 
 // Spell routes
-srd.route('/spells')
+rules.route('/spells')
     .get(spellController.getAll);
 
-srd.route('/spells/id/:id')
+rules.route('/spells/:id')
     .get(spellController.getById);
 
-srd.route('/spells/field/:field/:value')
+rules.route('/spells/field/:field/:value')
     .get(spellController.getByField);
 
-// srd.route('/spells/class/:className') // not ready yet
+// rules.route('/spells/class/:className') // not ready yet
 
-// srd.route('/spells/class/:className/level/:level') // not ready yet
+// rules.route('/spells/class/:className/level/:level') // not ready yet
 
 // Class routes
-srd.route('/classes')
+rules.route('/classes')
     .get(classController.getAll);
 
-srd.route('/classes/book/:bookId')
+rules.route('/classes/book/:bookId')
     .get(classController.getByBookId);
 
 // Feat routes
-srd.route('/feats')
+rules.route('/feats')
     .get(featController.getAll)
     .post(featController.create);
 
-srd.route('/feats/type/:type')
+rules.route('/feats/type/:type')
     .get(featController.getByType);
 
-srd.route('/feats/:id')
+rules.route('/feats/:id')
     .get(featController.getById)
     .patch(featController.updateById)
     .delete(featController.deleteById);
 
+// Skill routes
+rules.route('/skills')
+    .get(skillController.getAll);
+
+rules.route('/skills/:id')
+    .get(skillController.getById);
 
 
 // Book routes
-// srd.route('/sourcebooks') // not ready yet
+// rules.route('/sourcebooks') // not ready yet
 
-module.exports = srd
+module.exports = rules

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -4,7 +4,9 @@ const express = require('express');
 const srd = express.Router();
 const spellController = require('../controllers/spellController.js');
 const classController = require('../controllers/classController.js');
+const featController = require('../controllers/featController.js');
 
+// Spell routes
 srd.route('/spells')
     .get(spellController.getAll);
 
@@ -18,13 +20,29 @@ srd.route('/spells/field/:field/:value')
 
 // srd.route('/spells/class/:className/level/:level') // not ready yet
 
-
+// Class routes
 srd.route('/classes')
     .get(classController.getAll);
 
 srd.route('/classes/book/:bookId')
     .get(classController.getByBookId);
 
+// Feat routes
+srd.route('/feats')
+    .get(featController.getAll)
+    .post(featController.create);
+
+srd.route('/feats/type/:type')
+    .get(featController.getByType);
+
+srd.route('/feats/:id')
+    .get(featController.getById)
+    .patch(featController.updateById)
+    .delete(featController.deleteById);
+
+
+
+// Book routes
 // srd.route('/sourcebooks') // not ready yet
 
 module.exports = srd

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -6,6 +6,7 @@ const spellController = require('../controllers/spellController.js');
 const classController = require('../controllers/classController.js');
 const featController = require('../controllers/featController.js');
 const skillController = require('../controllers/skillController.js');
+const referenceController = require('../controllers/referenceController.js');
 
 // Spell routes
 rules.route('/spells')

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -42,6 +42,13 @@ rules.route('/feats/:id')
     .patch(featController.updateById)
     .delete(featController.deleteById);
 
+rules.route('/feats/:id/prereqs')
+    .post(featController.addPrereq);
+
+rules.route('/feats/:id/prereqs/:prereqId')
+    .patch(featController.updatePrereqById)
+    .delete(featController.deletePrereqById);
+
 // Skill routes
 rules.route('/skills')
     .get(skillController.getAll);

--- a/routes/rules.js
+++ b/routes/rules.js
@@ -48,8 +48,11 @@ rules.route('/skills')
 rules.route('/skills/:id')
     .get(skillController.getById);
 
-
 // Book routes
-// rules.route('/sourcebooks') // not ready yet
+rules.route('/sourcebooks')
+    .get(referenceController.getAll);
+
+rules.route('/sourcebooks/:id')
+    .get(referenceController.getById);
 
 module.exports = rules

--- a/scripts/backfill-user-roles.js
+++ b/scripts/backfill-user-roles.js
@@ -1,0 +1,56 @@
+require('dotenv').config();
+const { listUsers, getUserRoles, assignRole } = require('../services/auth0Management');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const PER_PAGE = 100;
+
+async function run() {
+  let page = 1;
+  let total = Infinity;
+  let checked = 0, assigned = 0, skipped = 0, failed = 0;
+  const failures = [];
+
+  while ((page - 1) * PER_PAGE < total) {
+    const result = await listUsers(page, PER_PAGE);
+    total = result.total;
+    if (!result.users.length) break;
+
+    for (const user of result.users) {
+      checked++;
+
+      try {
+        const roles = await getUserRoles(user.user_id);
+
+        if (roles.length > 0) {
+          skipped++;
+          continue;
+        }
+
+        if (DRY_RUN) {
+          console.log(`[dry-run] would assign User -> ${user.email} (${user.user_id})`);
+        } else {
+          await assignRole(user.user_id, 'User');
+          console.log(`assigned User -> ${user.email} (${user.user_id})`);
+        }
+        assigned++;
+      } catch (err) {
+        failed++;
+        failures.push({ user_id: user.user_id, email: user.email, error: err.message });
+        console.error(`FAILED -> ${user.email} (${user.user_id}): ${err.message}`);
+      }
+    }
+
+    page++;
+  }
+
+  console.log(`\nDone. checked=${checked} assigned=${assigned} skipped=${skipped} failed=${failed} dryRun=${DRY_RUN}`);
+  if (failures.length) {
+    console.log('\nFailures:');
+    failures.forEach((f) => console.log(`  ${f.email} (${f.user_id}): ${f.error}`));
+  }
+}
+
+run().catch((err) => {
+  console.error('Backfill crashed:', err);
+  process.exit(1);
+});

--- a/services/auth0Management.js
+++ b/services/auth0Management.js
@@ -1,0 +1,176 @@
+const domain = process.env.AUTH0_MGMT_DOMAIN;
+const clientId = process.env.AUTH0_MGMT_CLIENT_ID;
+const clientSecret = process.env.AUTH0_MGMT_CLIENT_SECRET;
+const audience = process.env.AUTH0_MGMT_AUDIENCE;
+
+let cachedToken = null;
+let tokenExpiry = 0;
+let cachedRoleMap = null;
+let roleMapExpiry = 0;
+const ROLE_MAP_TTL_MS = 10 * 60 * 1000;
+
+
+// Token management
+async function getManagementToken() {
+    if (cachedToken && Date.now() < tokenExpiry - 60000) return cachedToken;
+
+    const res = await fetch(`https://${domain}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type:    'client_credentials',
+      client_id:     clientId,
+      client_secret: clientSecret,
+      audience,
+    }),
+  });
+
+  if (!res.ok) {
+    throw await buildAuth0Error(res, 'Auth0 token fetch failed');
+  }
+
+  const data = await res.json();
+  cachedToken  = data.access_token;
+  tokenExpiry  = Date.now() + data.expires_in * 1000;
+  return cachedToken;
+
+}
+
+// Internal helper functions
+async function auth0Fetch(path, options = {}) {
+  const token = await getManagementToken();
+  const res = await fetch(`https://${domain}/api/v2${path}`, {
+    ...options,
+    headers: {
+      Authorization:  `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (!res.ok) throw await buildAuth0Error(res, `Auth0 API error on ${path}`);
+
+  // DELETE /roles returns 204 no body
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+function clampInt(value, fallback, min, max) {
+  if (value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+async function buildAuth0Error(res, context) {
+  let rawBody = '';
+
+  try {
+    rawBody = await res.text();
+  } catch {
+    rawBody = '';
+  }
+
+  let errorBody = rawBody;
+
+  try {
+    errorBody = rawBody ? JSON.parse(rawBody) : null;
+  } catch {
+    errorBody = rawBody || null;
+  }
+
+  const message =
+    errorBody && typeof errorBody === 'object'
+      ? errorBody.message || errorBody.error_description || errorBody.error
+      : errorBody;
+
+  const err = new Error(
+    `${context}: ${res.status}${message ? ` - ${message}` : ''}`
+  );
+
+  err.status = res.status;
+  err.auth0 = {
+    status: res.status,
+    error: errorBody && typeof errorBody === 'object' ? errorBody.error : undefined,
+    message: message || undefined,
+  };
+
+  return err;
+}
+
+// Role map (name -> id)
+
+async function getRoleMap() {
+  if (cachedRoleMap && Date.now() < roleMapExpiry) return cachedRoleMap;
+
+  const roles = await auth0Fetch('/roles');
+  cachedRoleMap = Object.fromEntries(roles.map(r => [r.name, r.id]));
+  roleMapExpiry = Date.now() + ROLE_MAP_TTL_MS;
+
+  return cachedRoleMap;
+}
+
+// Public API
+
+async function listUsers(page = 1, perPage = 50, query = '') {
+  const safePage = clampInt(page, 1, 1, 1000);
+  const safePerPage = clampInt(perPage, 50, 1, 100);
+
+  const params = new URLSearchParams({
+    page: safePage - 1, // Auth0 is 0-indexed
+    per_page: safePerPage,
+    include_totals: true,
+  });
+
+  if (query) params.set('q', query);
+  return auth0Fetch(`/users?${params}`);
+}
+
+async function getUserRoles(userId) {
+  return auth0Fetch(`/users/${encodeURIComponent(userId)}/roles`);
+}
+
+async function assignRole(userId, roleName) {
+  const roleMap = await getRoleMap();
+  const roleId = roleMap[roleName];
+
+  if (!roleId) {
+    const err = new Error(`Unknown role: ${roleName}`);
+    err.status = 400;
+    throw err;
+  }
+
+  return auth0Fetch(`/users/${encodeURIComponent(userId)}/roles`, {
+    method: 'POST',
+    body: JSON.stringify({ roles: [roleId] }),
+  });
+}
+
+async function removeRole(userId, roleName) {
+  const roleMap = await getRoleMap();
+  const roleId = roleMap[roleName];
+
+  if (!roleId) {
+    const err = new Error(`Unknown role: ${roleName}`);
+    err.status = 400;
+    throw err;
+  }
+
+  return auth0Fetch(`/users/${encodeURIComponent(userId)}/roles`, {
+    method: 'DELETE',
+    body: JSON.stringify({ roles: [roleId] }),
+  });
+}
+
+async function getRoleUsers(roleId) {
+  return auth0Fetch(`/roles/${encodeURIComponent(roleId)}/users`);
+}
+
+module.exports = { 
+    getRoleMap, 
+    listUsers, 
+    getUserRoles, 
+    assignRole, 
+    removeRole, 
+    getRoleUsers
+};


### PR DESCRIPTION
## Summary
- Implements GET /rules/skills and GET /rules/skills/:id (RPGT-20)
- Implements full CRUD for /rules/feats, including GET /rules/feats/type/:type and prerequisite nesting (RPGT-21)
- getFeatById fetches feat and feat_prerequisites concurrently via Promise.all(), returning prerequisites as a nested array on the feat object
- Validates name, source_book_id, and benefit on feat create (all three are NOT NULL in schema)
- Routes file renamed from srd variable naming to rules throughout; spell route fixed from /spells/id/:id to /spells/:id

## Notes
- prereq_feat_id / prereq_skill_id will be NULL until the pdf-extractor importer resolves prerequisite names to IDs (tracked separately)
- Weak id validation in getById handlers is tracked in RPGT-129

## Test plan
- [x] GET /rules/skills returns all skills with count in meta
- [x] GET /rules/skills/:id returns single skill or 404
- [x] GET /rules/feats returns all feats
- [x] GET /rules/feats/1 returns feat with prerequisites array (tested: Ancestral Relic)
- [x] GET /rules/feats/type/:type returns feats filtered by type
- [x] POST /rules/feats validates required fields, returns 201 with created feat
- [x] PATCH /rules/feats/:id updates and returns updated feat
- [x] DELETE /rules/feats/:id deletes and returns success message

Refs: RPGT-20, RPGT-21

Generated with Claude Code